### PR TITLE
Fix 04 bugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -952,6 +952,7 @@ dependencies = [
  "cairo-lang-sierra-to-casm",
  "cairo-lang-starknet",
  "cairo-lang-syntax",
+ "cairo-lang-utils",
  "itertools",
  "pyo3",
  "serde",

--- a/crates/cairo-lang-python-bindings/Cargo.toml
+++ b/crates/cairo-lang-python-bindings/Cargo.toml
@@ -16,6 +16,7 @@ cairo-lang-plugins = { path = "../cairo-lang-plugins", version = "1.0.0-alpha.2"
 cairo-lang-sierra-generator = { path = "../cairo-lang-sierra-generator", version = "1.0.0-alpha.2" }
 cairo-lang-diagnostics = { path = "../cairo-lang-diagnostics", version = "1.0.0-alpha.2" }
 cairo-lang-defs = { path = "../cairo-lang-defs", version = "1.0.0-alpha.2" }
+cairo-lang-utils = { path = "../cairo-lang-utils", version = "1.0.0-alpha.2" }
 cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "1.0.0-alpha.2" }
 cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "1.0.0-alpha.2" }
 cairo-lang-protostar = { path = "../cairo-lang-protostar" }

--- a/crates/cairo-lang-python-bindings/src/lib.rs
+++ b/crates/cairo-lang-python-bindings/src/lib.rs
@@ -162,7 +162,7 @@ fn validate_tests(sierra_program: Program, test_names: &Vec<String>) -> Result<(
                 anyhow::bail!("Test function {} must be panicable but it's not", test);
             }
             if return_type_name != "core::PanicResult::<()>" {
-                anyhow::bail!("Test function {} returns a value, it is required that test functions do not return values", test);
+                anyhow::bail!("Test function {} returns a value {}, it is required that test functions do not return values", test, return_type_name);
             }
         } else {
             anyhow::bail!("Couldn't read result type for test function {}poassible cause: Test function {} must be panicable but it's not", test, test);

--- a/crates/cairo-lang-python-bindings/src/lib.rs
+++ b/crates/cairo-lang-python-bindings/src/lib.rs
@@ -161,7 +161,7 @@ fn validate_tests(sierra_program: Program, test_names: &Vec<String>) -> Result<(
             if !return_type_name.starts_with("core::PanicResult::") {
                 anyhow::bail!("Test function {} must be panicable but it's not", test);
             }
-            if return_type_name != "core::PanicResult::<()>" {
+            if return_type_name != "core::PanicResult::<((),)>" {
                 anyhow::bail!("Test function {} returns a value {}, it is required that test functions do not return values", test, return_type_name);
             }
         } else {

--- a/crates/cairo-lang-python-bindings/src/lib.rs
+++ b/crates/cairo-lang-python-bindings/src/lib.rs
@@ -84,7 +84,6 @@ fn collect_tests(input_path: &str, output_path: Option<&str>, maybe_cairo_paths:
     let main_crate_ids = setup_project(db, Path::new(&input_path)).map_err(|e| PyErr::new::<RuntimeError, _>(format!("Failed to setup project for path({}): {}", input_path, e.to_string())))?;
     if let Some(cairo_paths) = maybe_cairo_paths {
         for cairo_path in cairo_paths {
-            println!("{}", cairo_path);
             setup_project(db, Path::new(cairo_path)).map_err(|e| PyErr::new::<RuntimeError, _>(format!("Failed to add cairo path({}): {}", cairo_path, e.to_string())))?;
         }
     }

--- a/crates/cairo-lang-python-bindings/src/lib.rs
+++ b/crates/cairo-lang-python-bindings/src/lib.rs
@@ -84,6 +84,7 @@ fn collect_tests(input_path: &str, output_path: Option<&str>, maybe_cairo_paths:
     let main_crate_ids = setup_project(db, Path::new(&input_path)).map_err(|e| PyErr::new::<RuntimeError, _>(format!("Failed to setup project for path({}): {}", input_path, e.to_string())))?;
     if let Some(cairo_paths) = maybe_cairo_paths {
         for cairo_path in cairo_paths {
+            println!("{}", cairo_path);
             setup_project(db, Path::new(cairo_path)).map_err(|e| PyErr::new::<RuntimeError, _>(format!("Failed to add cairo path({}): {}", cairo_path, e.to_string())))?;
         }
     }

--- a/crates/cairo-lang-python-bindings/src/lib.rs
+++ b/crates/cairo-lang-python-bindings/src/lib.rs
@@ -36,6 +36,7 @@ use cairo_lang_semantic::{ConcreteFunction, FunctionLongId};
 use cairo_lang_semantic::items::functions::GenericFunctionId;
 use cairo_lang_semantic::items::functions::ConcreteFunctionWithBodyId;
 use cairo_lang_debug::debug::DebugWithDb;
+use cairo_lang_utils::extract_matches;
 use itertools::Itertools;
 
 use cairo_lang_sierra::program::{GenericArg, Program};
@@ -151,6 +152,7 @@ fn validate_tests(sierra_program: Program, test_names: &Vec<String>) -> Result<(
         let signature = &func.signature;
         let tp = &signature.ret_types[0];
         let info = casm_generator.get_info(&tp);
+        let inner_ty = extract_matches!(&info.long_id.generic_args[1], GenericArg::Type);
         let mut maybe_return_type_name = None;
         if info.long_id.generic_id == EnumType::ID {
             if let GenericArg::UserType(ut) = &info.long_id.generic_args[0] {
@@ -162,10 +164,10 @@ fn validate_tests(sierra_program: Program, test_names: &Vec<String>) -> Result<(
                 anyhow::bail!("Test function {} must be panicable but it's not", test);
             }
             if return_type_name != "core::PanicResult::<((),)>" {
-                anyhow::bail!("Test function {} returns a value {}, it is required that test functions do not return values", test, return_type_name);
+                anyhow::bail!("Test function {} returns a value {}, it is required that test functions do not return values", test, inner_ty);
             }
         } else {
-            anyhow::bail!("Couldn't read result type for test function {}poassible cause: Test function {} must be panicable but it's not", test, test);
+            anyhow::bail!("Couldn't read result type for test function {} possible cause: Test function {} must be panicable but it's not", test, test);
         }
     };
 


### PR DESCRIPTION
Currently test `tests/integration/cairo1_compiler_bindings/tests_collector_and_compiler_test.py::test_cairo_path_for_tests` fails with error

```
Detailed error information: error: Identifier not found.
 --> test_with_deps.cairo:1:5
use external_lib_foo::foo::foo;
    ^**************^

error: Identifier not found.
 --> test_with_deps.cairo:2:5
use external_lib_bar::bar::bar;
    ^**************^

Detailed error information: error: Identifier not found.
 --> test_with_deps.cairo:2:5
use external_lib_bar::bar::bar;
    ^**************^
```
