### PR TITLE
Revert verify path for sierra to casm

### DIFF
--- a/crates/cairo-lang-python-bindings/src/lib.rs
+++ b/crates/cairo-lang-python-bindings/src/lib.rs
@@ -107,8 +107,6 @@ fn compile_starknet_contract_sierra_to_casm_from_path(
     input_path: &str,
     output_path: Option<&str>,
 ) -> PyResult<Option<String>> {
-    ensure_path_is_dir(input_path)
-        .map_err(|e| PyErr::new::<RuntimeError, _>(format!("{:?}", e)))?;
     let sierra = fs::read_to_string(input_path).expect("Could not read file!");
     let casm = starknet_sierra_to_casm(&sierra)
         .map_err(|e| PyErr::new::<RuntimeError, _>(format!("{:?}", e)))?;


### PR DESCRIPTION
I think we should revert one change from https://github.com/software-mansion-labs/cairo/commit/bced238487aad171b52dc4551d722b97948b85e9: we should not require a path to a folder when compiling from sierra to casm, we should require a sierra file path.